### PR TITLE
Fix Source URL

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ var PersonIcon = L.Icon.extend({
 
 // load up the background tile layer
 // var Stamen_Watercolor = L.tileLayer('http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg', {}).addTo(map);
-var Stamen_Watercolor = L.tileLayer('//stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg', {}).addTo(map);
+var Stamen_Watercolor = L.tileLayer('//tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg', {}).addTo(map);
 // all the facemarkers will go into one layer//stamen-tiles-c.a.ssl.fastly.net/watercolor/12/655/1583.jpg
 // var facemarkers = L.markerClusterGroup({
 // animate: true,


### PR DESCRIPTION
Found new source by first searching for original source, going to the webpage with the watercolor map, then inspecting the source HTML to find the reference image URLs that match the pattern '//tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg', which is now in the code (see line 26 of main.js)